### PR TITLE
Expose nanosleep() and clock_gettime() in time.h header

### DIFF
--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -216,6 +216,15 @@ int _EXFUN(nanosleep, (const struct timespec  *rqtp, struct timespec *rmtp));
 #endif
 #endif /* _POSIX_TIMERS */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+int _EXFUN(clock_gettime, (clockid_t clock_id, struct timespec *tp));
+int _EXFUN(nanosleep, (const struct timespec  *rqtp, struct timespec *rmtp));
+#ifdef __cplusplus
+}
+#endif
+
 #if defined(_POSIX_CLOCK_SELECTION)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Defining _POSIX_TIMERS would also work, but not all of those functions
are implemented.