### PR TITLE
Make rust_begin_panic() both no_mangle and weakly linked

### DIFF
--- a/newlib/libc/sys/redox/src/lib.rs
+++ b/newlib/libc/sys/redox/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(collections, lang_items, core_intrinsics, compiler_builtins_lib)]
+#![feature(collections, lang_items, core_intrinsics, compiler_builtins_lib, linkage)]
 #![allow(non_camel_case_types)]
 
 extern crate syscall;
@@ -91,6 +91,8 @@ pub unsafe extern "C" fn __errno_location() -> *mut c_int {
 }
 
 #[lang = "panic_fmt"]
+#[linkage = "weak"]
+#[no_mangle]
 pub extern fn rust_begin_panic(_msg: core::fmt::Arguments,
                                _file: &'static str,
                                _line: u32) -> ! {


### PR DESCRIPTION
I'm not 100% sure this is the correct solution, but it appears to make
both Rust and C code compile and link.