### PR TITLE
Use "-C metadata=newlib"

### DIFF
--- a/newlib/libc/sys/redox/.cargo/config
+++ b/newlib/libc/sys/redox/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "metadata=newlib_redox"]


### PR DESCRIPTION
Prevents symbol conflicts when linking Rust application.