### PR TITLE
Berkeley sockets API, version 2

### DIFF
--- a/newlib/libc/sys/redox/Cargo.toml
+++ b/newlib/libc/sys/redox/Cargo.toml
@@ -11,3 +11,4 @@ lto = true
 
 [dependencies]
 redox_syscall = "0.1"
+byteorder = { version = "1", default-features = false }

--- a/newlib/libc/sys/redox/Makefile.am
+++ b/newlib/libc/sys/redox/Makefile.am
@@ -17,9 +17,16 @@ rust_sources = \
     src/process.rs \
     src/file.rs \
     src/time.rs \
-    src/unimpl.rs
+    src/folder.rs \
+    src/unimpl.rs \
+    src/socket.rs \
+    src/types.rs \
+    src/hostname.rs \
+    src/dns/answer.rs \
+    src/dns/mod.rs \
+    src/dns/query.rs
 
-$(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Cargo.toml $(rust_sources)
+$(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Xargo.toml Cargo.toml $(rust_sources)
 	cd $(srcdir); CC=x86_64-elf-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
 
 lib.a: $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a

--- a/newlib/libc/sys/redox/Makefile.am
+++ b/newlib/libc/sys/redox/Makefile.am
@@ -33,3 +33,7 @@ ACLOCAL_AMFLAGS = -I ../../..
 CONFIG_STATUS_DEPENDENCIES = $(newlib_basedir)/configure.host
 
 include $(srcdir)/../../../Makefile.shared
+
+install-data-local:
+	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/arpa;
+	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/netinet;

--- a/newlib/libc/sys/redox/include/arpa/inet.h
+++ b/newlib/libc/sys/redox/include/arpa/inet.h
@@ -1,0 +1,16 @@
+#ifndef _ARPA_INET_H
+#define _ARPA_INET_H
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <netinet/in.h>
+
+uint32_t htonl(uint32_t hostlong);
+uint16_t htons(uint16_t hostshort);
+uint32_t ntohl(uint32_t netlong);
+uint16_t ntohs(uint16_t netshort);
+
+char *inet_ntoa(struct in_addr in);
+int inet_aton(const char *cp, struct in_addr *inp);
+
+#endif

--- a/newlib/libc/sys/redox/include/netdb.h
+++ b/newlib/libc/sys/redox/include/netdb.h
@@ -1,0 +1,14 @@
+#ifndef _NETDB_H
+#define _NETDB_H
+
+struct hostent {
+    char *h_name;
+    char **h_aliases;
+    int h_addrtype;
+    int h_length;
+    char **h_addr_list;
+};
+
+struct hostent *gethostbyname(const char *name);
+
+#endif

--- a/newlib/libc/sys/redox/include/netinet/in.h
+++ b/newlib/libc/sys/redox/include/netinet/in.h
@@ -1,0 +1,28 @@
+#ifndef _NETINET_IN_H
+#define _NETINET_IN_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#define	IPPROTO_IP 0
+// IPPROTO_IPV6
+#define	IPPROTO_ICMP 1
+#define	IPPROTO_TCP 6
+#define	IPPROTO_UDP 17
+
+typedef uint16_t sa_family_t;
+typedef uint32_t in_addr_t;
+typedef uint16_t in_port_t;
+
+struct in_addr {
+    in_addr_t s_addr;
+};
+
+struct sockaddr_in {
+    sa_family_t sin_family;
+    in_port_t sin_port;
+    struct in_addr sin_addr;
+    unsigned char __pad[8];
+};
+
+#endif

--- a/newlib/libc/sys/redox/include/time.h
+++ b/newlib/libc/sys/redox/include/time.h
@@ -285,15 +285,11 @@ extern "C" {
 
 #endif
 
-#if defined(_POSIX_MONOTONIC_CLOCK)
-
 /*  The identifier for the system-wide monotonic clock, which is defined
  *      as a clock whose value cannot be set via clock_settime() and which 
  *          cannot have backward clock jumps. */
 
 #define CLOCK_MONOTONIC (clockid_t)4
-
-#endif
 
 #if defined(_POSIX_CPUTIME)
 

--- a/newlib/libc/sys/redox/src/dns/answer.rs
+++ b/newlib/libc/sys/redox/src/dns/answer.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use collections::String;
+use collections::Vec;
+
+#[derive(Clone, Debug)]
+pub struct DnsAnswer {
+    pub name: String,
+    pub a_type: u16,
+    pub a_class: u16,
+    pub ttl_a: u16,
+    pub ttl_b: u16,
+    pub data: Vec<u8>
+}

--- a/newlib/libc/sys/redox/src/dns/mod.rs
+++ b/newlib/libc/sys/redox/src/dns/mod.rs
@@ -1,0 +1,212 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use self::answer::DnsAnswer;
+pub use self::query::DnsQuery;
+
+use core::slice;
+use core::u16;
+use collections::String;
+use collections::Vec;
+
+mod answer;
+mod query;
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(packed)]
+pub struct n16 {
+    inner: u16
+}
+
+impl n16 {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts((&self.inner as *const u16) as *const u8, 2) }
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        n16 {
+            inner: unsafe { slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len()/2)[0] }
+        }
+    }
+}
+
+impl From<u16> for n16 {
+    fn from(value: u16) -> Self {
+        n16 {
+            inner: value.to_be()
+        }
+    }
+}
+
+impl From<n16> for u16 {
+    fn from(value: n16) -> Self {
+        u16::from_be(value.inner)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Dns {
+    pub transaction_id: u16,
+    pub flags: u16,
+    pub queries: Vec<DnsQuery>,
+    pub answers: Vec<DnsAnswer>
+}
+
+impl Dns {
+    pub fn compile(&self) -> Vec<u8> {
+        let mut data = Vec::new();
+
+        macro_rules! push_u8 {
+            ($value:expr) => {
+                data.push($value);
+            };
+        };
+
+        macro_rules! push_n16 {
+            ($value:expr) => {
+                data.extend_from_slice(n16::from($value).as_bytes());
+            };
+        };
+
+        push_n16!(self.transaction_id);
+        push_n16!(self.flags);
+        push_n16!(self.queries.len() as u16);
+        push_n16!(self.answers.len() as u16);
+        push_n16!(0);
+        push_n16!(0);
+
+        for query in self.queries.iter() {
+            for part in query.name.split('.') {
+                push_u8!(part.len() as u8);
+                data.extend_from_slice(part.as_bytes());
+            }
+            push_u8!(0);
+            push_n16!(query.q_type);
+            push_n16!(query.q_class);
+        }
+
+        data
+    }
+
+    pub fn parse(data: &[u8]) -> Result<Self, String> {
+        let mut i = 0;
+
+        macro_rules! pop_u8 {
+            () => {
+                {
+                    i += 1;
+                    if i > data.len() {
+                        return Err(format!("{}: {}: pop_u8", file!(), line!()));
+                    }
+                    data[i - 1]
+                }
+            };
+        };
+
+        macro_rules! pop_n16 {
+            () => {
+                {
+                    i += 2;
+                    if i > data.len() {
+                        return Err(format!("{}: {}: pop_n16", file!(), line!()));
+                    }
+                    u16::from(n16::from_bytes(&data[i - 2 .. i]))
+                }
+            };
+        };
+
+        macro_rules! pop_data {
+            () => {
+                {
+                    let mut data = Vec::new();
+
+                    let data_len = pop_n16!();
+                    for _data_i in 0..data_len {
+                        data.push(pop_u8!());
+                    }
+
+                    data
+                }
+            };
+        };
+
+        macro_rules! pop_name {
+            () => {
+                {
+                    let mut name = String::new();
+
+                    loop {
+                        let name_len = pop_u8!();
+                        if name_len == 0 {
+                            break;
+                        }
+                        if ! name.is_empty() {
+                            name.push('.');
+                        }
+                        for _name_i in 0..name_len {
+                            name.push(pop_u8!() as char);
+                        }
+                    }
+
+                    name
+                }
+            };
+        };
+
+        let transaction_id = pop_n16!();
+        let flags = pop_n16!();
+        let queries_len = pop_n16!();
+        let answers_len = pop_n16!();
+        pop_n16!();
+        pop_n16!();
+
+        let mut queries = Vec::new();
+        for _query_i in 0..queries_len {
+            queries.push(DnsQuery {
+                name: pop_name!(),
+                q_type: pop_n16!(),
+                q_class: pop_n16!()
+            });
+        }
+
+        let mut answers = Vec::new();
+        for _answer_i in 0..answers_len {
+            let name_ind = 0b11000000;
+            let name_test = pop_u8!();
+            i -= 1;
+
+            answers.push(DnsAnswer {
+                name: if name_test & name_ind == name_ind {
+                    let name_off = pop_n16!() - ((name_ind as u16) << 8);
+                    let old_i = i;
+                    i = name_off as usize;
+                    let name = pop_name!();
+                    i = old_i;
+                    name
+                } else {
+                    pop_name!()
+                },
+                a_type: pop_n16!(),
+                a_class: pop_n16!(),
+                ttl_a: pop_n16!(),
+                ttl_b: pop_n16!(),
+                data: pop_data!()
+            });
+        }
+
+        Ok(Dns {
+            transaction_id: transaction_id,
+            flags: flags,
+            queries: queries,
+            answers: answers,
+        })
+    }
+}

--- a/newlib/libc/sys/redox/src/dns/query.rs
+++ b/newlib/libc/sys/redox/src/dns/query.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use collections::String;
+
+#[derive(Clone, Debug)]
+pub struct DnsQuery {
+    pub name: String,
+    pub q_type: u16,
+    pub q_class: u16
+}

--- a/newlib/libc/sys/redox/src/hostname.rs
+++ b/newlib/libc/sys/redox/src/hostname.rs
@@ -53,7 +53,7 @@ fn lookup_host(host: &str) -> Result<LookupHost> {
 
         let packet_data = packet.compile();
 
-        let fd = syscall::open(format!("udp:{}.{}.{}.{}:0", 
+        let fd = syscall::open(format!("udp:{}.{}.{}.{}:0",
                                        ip[0], ip[1], ip[2], ip[3]).as_bytes(),
                                syscall::O_RDWR)?;
 
@@ -82,7 +82,7 @@ fn lookup_host(host: &str) -> Result<LookupHost> {
                     if answer.a_type == 0x0001 && answer.a_class == 0x0001
                        && answer.data.len() == 4
                     {
-                        let addr = in_addr{ 
+                        let addr = in_addr {
                             s_addr: [answer.data[0], answer.data[1], answer.data[2], answer.data[3]]
                         };
                         addrs.push(addr);

--- a/newlib/libc/sys/redox/src/hostname.rs
+++ b/newlib/libc/sys/redox/src/hostname.rs
@@ -1,0 +1,126 @@
+use core::ptr::null;
+use core::{mem, str};
+use collections::vec::IntoIter;
+use collections::string::ToString;
+use collections::{Vec, String};
+use ::dns::{Dns, DnsQuery};
+use syscall::{self, Result, EINVAL, Error};
+use ::types::{in_addr, hostent, c_char};
+
+static mut HOST_ENTRY: hostent = hostent { h_name: null(), h_aliases: null(), h_addrtype: 0, h_length: 0, h_addr_list: null() };
+static mut HOST_NAME: Option<Vec<u8>> = None;
+static mut HOST_ALIASES: [*const c_char; 1] = [null()];
+static mut HOST_ADDR: Option<in_addr> = None;
+static mut HOST_ADDR_LIST: [*const c_char; 2] = [null(); 2];
+
+struct LookupHost(IntoIter<in_addr>);
+
+impl Iterator for LookupHost {
+    type Item = in_addr;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+// Modified from rust/sys/redox/net/mod.rs
+fn lookup_host(host: &str) -> Result<LookupHost> {
+    // XXX better error handling
+    let ip_string = String::from_utf8(::file_read_all("/etc/net/ip")?)
+        .or(Err(Error::new(syscall::EIO)))?;
+    let ip: Vec<u8> = ip_string.trim().split(".").map(|part| part.parse::<u8>()
+                               .unwrap_or(0)).collect();
+
+    let dns_string = String::from_utf8(::file_read_all("/etc/net/dns")?)
+        .or(Err(Error::new(syscall::EIO)))?;
+    let dns: Vec<u8> = dns_string.trim().split(".").map(|part| part.parse::<u8>()
+                                 .unwrap_or(0)).collect();
+
+    if ip.len() == 4 && dns.len() == 4 {
+        let mut timespec = syscall::TimeSpec::default();
+        syscall::clock_gettime(syscall::CLOCK_REALTIME, &mut timespec).unwrap();
+        let tid = (timespec.tv_nsec >> 16) as u16;
+
+        let packet = Dns {
+            transaction_id: tid,
+            flags: 0x0100,
+            queries: vec![DnsQuery {
+                name: host.to_string(),
+                q_type: 0x0001,
+                q_class: 0x0001,
+            }],
+            answers: vec![]
+        };
+
+        let packet_data = packet.compile();
+
+        let fd = syscall::open(format!("udp:{}.{}.{}.{}:0", 
+                                       ip[0], ip[1], ip[2], ip[3]).as_bytes(),
+                               syscall::O_RDWR)?;
+
+        let timeout = syscall::TimeSpec {
+            tv_sec: 5,
+            tv_nsec: 0,
+        };
+        let rt = syscall::dup(fd, b"read_timeout")?;
+        syscall::write(rt, &timeout)?;
+        syscall::close(rt)?;
+        let wt = syscall::dup(fd, b"write_timeout")?;
+        syscall::write(wt, &timeout)?;
+        syscall::close(wt)?;
+
+        let sendrecvfd = syscall::dup(fd, format!("{}.{}.{}.{}:53", dns[0], dns[1], dns[2], dns[3]).as_bytes())?;
+        syscall::write(sendrecvfd, &packet_data)?;
+        let mut buf = [0; 65536];
+        let count = syscall::read(sendrecvfd, &mut buf)?;
+        syscall::close(sendrecvfd)?;
+        syscall::close(fd)?;
+
+        match Dns::parse(&buf[.. count]) {
+            Ok(response) => {
+                let mut addrs = vec![];
+                for answer in response.answers.iter() {
+                    if answer.a_type == 0x0001 && answer.a_class == 0x0001
+                       && answer.data.len() == 4
+                    {
+                        let addr = in_addr{ 
+                            s_addr: [answer.data[0], answer.data[1], answer.data[2], answer.data[3]]
+                        };
+                        addrs.push(addr);
+                    }
+                }
+                Ok(LookupHost(addrs.into_iter()))
+            },
+            Err(_err) => Err(Error::new(EINVAL))
+        }
+    } else {
+        Err(Error::new(EINVAL))
+    }
+}
+
+libc_fn!(unsafe gethostbyname(name: *const c_char) -> Result<*const hostent> {
+    // XXX h_errno
+    let mut addr = mem::uninitialized();
+    let host_addr = if ::socket::inet_aton(name, &mut addr) == 1 {
+        addr
+    } else {
+        // XXX
+        let mut host = lookup_host(str::from_utf8_unchecked(::cstr_to_slice(name)))?;
+        host.next().ok_or(Error::new(syscall::ENOENT))? // XXX
+    };
+
+    let host_name: Vec<u8> = ::cstr_to_slice(name).to_vec();
+    HOST_ADDR_LIST = [host_addr.s_addr.as_ptr() as *const c_char, null()];
+    HOST_ADDR = Some(host_addr);
+
+    HOST_ENTRY = hostent {
+        h_name: host_name.as_ptr() as *const c_char,
+        h_aliases: HOST_ALIASES.as_ptr(),
+        h_addrtype: ::socket::AF_INET,
+        h_length: 4,
+        h_addr_list: HOST_ADDR_LIST.as_ptr()
+    };
+
+    HOST_NAME = Some(host_name);
+
+    Ok(&HOST_ENTRY as *const hostent)
+});

--- a/newlib/libc/sys/redox/src/lib.rs
+++ b/newlib/libc/sys/redox/src/lib.rs
@@ -1,10 +1,11 @@
 #![no_std]
-#![feature(collections, lang_items, core_intrinsics, compiler_builtins_lib, linkage)]
+#![feature(collections, lang_items, core_intrinsics, compiler_builtins_lib, linkage, drop_types_in_const)]
 
 extern crate syscall;
 #[macro_use]
 extern crate collections;
 extern crate compiler_builtins;
+extern crate byteorder;
 
 use core::{ptr, mem, intrinsics, slice};
 use collections::Vec;
@@ -18,6 +19,7 @@ pub mod folder;
 pub mod time;
 pub mod unimpl;
 pub mod redox;
+pub mod socket;
 mod types;
 
 extern {

--- a/newlib/libc/sys/redox/src/macros.rs
+++ b/newlib/libc/sys/redox/src/macros.rs
@@ -35,6 +35,7 @@ int_fail!(i8);
 int_fail!(i16);
 int_fail!(i32);
 int_fail!(i64);
+int_fail!(isize);
 
 /// If `res` is `Err(..)`, set `errno` and return `-1` or `NULL`, otherwise
 /// unwrap.

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -1,6 +1,6 @@
 use core::str::{self, FromStr};
 use ::types::{c_int, c_char, size_t, c_void, ssize_t, socklen_t, in_addr, sockaddr, sockaddr_in};
-use syscall::{self, O_RDWR};
+use syscall::{self, O_RDWR, O_WRONLY};
 use syscall::error::{Error, EPROTOTYPE, EPROTONOSUPPORT, EAFNOSUPPORT, EINVAL, EOPNOTSUPP};
 use core::slice;
 use collections::Vec;
@@ -86,6 +86,31 @@ libc_fn!(unsafe send(socket: c_int, buffer: *const c_void, length: size_t, flags
     } else {
         let buf = slice::from_raw_parts(buffer as *const u8, length);
         Ok(syscall::write(socket as usize, buf)? as ssize_t)
+    }
+});
+
+libc_fn!(unsafe recvfrom(socket: c_int, buffer: *mut c_void, length: size_t, flags: c_int, address: *const sockaddr, _address_len: *const socklen_t) -> Result<ssize_t>  {
+    let fd = syscall::dup(socket as usize, b"listen")?;
+    let mut path = [0; 4096];
+    syscall::fpath(socket as usize, &mut path)?;
+    // XXX process path and write to address
+    let ret = recv(socket, buffer, length, flags);
+    syscall::close(fd)?;
+    Ok(ret)
+});
+
+libc_fn!(unsafe sendto(socket: c_int, message: *const c_void, length: size_t, flags: c_int, dest_addr: *const sockaddr, _dest_len: socklen_t) -> Result<ssize_t> {
+    // XXX test dest_len
+    if (*dest_addr).sa_family as i32 == AF_INET {
+        let addr = &*(dest_addr as *const sockaddr_in);
+        let s_addr = addr.sin_addr.s_addr;
+        let url = format!("{}.{}.{}.{}:{}", s_addr[0], s_addr[1], s_addr[2], s_addr[3], ntohs(addr.sin_port));
+        let fd = syscall::dup(socket as usize, url.as_bytes())?;
+        let ret = send(fd as c_int, message, length, flags);
+        syscall::close(fd)?;
+        Ok(ret)
+    } else {
+        Err(Error::new(EOPNOTSUPP))
     }
 });
 

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -217,3 +217,9 @@ libc_fn!(ntohl(netlong: [u8; 4]) -> u32 {
 libc_fn!(ntohs(netshort: [u8; 2]) -> u16 {
     BigEndian::read_u16(&netshort)
 });
+
+libc_fn!(setsockopt(socket: c_int, level: c_int, option_name: c_int, option_value: *const c_void, option_len: socklen_t) -> Result<c_int> {
+    syscall::write(2, format!("unimplemented: setsockopt({}, {}, {}, {:?}, {})\n",
+                              socket, level, option_name, option_value, option_len).as_bytes()).unwrap();
+    Err(Error::new(syscall::ENOSYS))
+});

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -1,0 +1,110 @@
+use core::str::{self, FromStr};
+use ::types::{c_int, c_char, size_t, c_void, ssize_t, socklen_t, in_addr, sockaddr, sockaddr_in};
+use syscall::{self, O_RDWR};
+use syscall::error::{Error, EPROTOTYPE, EPROTONOSUPPORT, EAFNOSUPPORT, EINVAL, EOPNOTSUPP};
+use core::slice;
+use collections::Vec;
+use byteorder::{BigEndian, ByteOrder};
+
+
+const AF_INET: c_int = 2;
+const SOCK_STREAM: c_int = 1;
+const SOCK_DGRAM: c_int = 2;
+
+static mut NTOA_ADDR: Option<Vec<u8>> = None;
+
+libc_fn!(unsafe inet_aton(cp: *const c_char, inp: *mut in_addr) -> c_int {
+    // TODO: octal/hex; more modern functions
+    let addr = &mut (*inp).s_addr;
+    let mut octets = str::from_utf8_unchecked(::cstr_to_slice(cp)).split('.');
+    for i in 0..4 {
+        if let Some(n) = octets.next().and_then(|x| u8::from_str(x).ok()) {
+            addr[i] = n;
+        } else {
+            return 0;
+        }
+    }
+    if octets.next() == None {
+        1 // Success
+    } else {
+        0
+    }
+});
+
+libc_fn!(unsafe inet_ntoa(inp: *const in_addr) -> *const c_char {
+    let s_addr = (*inp).s_addr;
+    let addr = format!("{}.{}.{}.{}\0", s_addr[0], s_addr[1], s_addr[2], s_addr[3]).into_bytes();
+    let ptr = addr.as_ptr();
+    NTOA_ADDR = Some(addr);
+    ptr as *const c_char
+});
+
+libc_fn!(unsafe socket(domain: c_int, type_: c_int, protocol: c_int) -> Result<c_int> {
+    if domain != AF_INET {
+        Err(Error::new(EAFNOSUPPORT))
+    } else if protocol != 0 {
+        Err(Error::new(EPROTONOSUPPORT))
+    } else {
+        let fd = match type_ {
+            SOCK_STREAM => syscall::open("tcp:", O_RDWR),
+            SOCK_DGRAM => syscall::open("udp:", O_RDWR),
+            _ => Err(Error::new(EPROTOTYPE))
+        }?;
+        Ok(fd as c_int)
+    }
+});
+
+libc_fn!(unsafe connect(socket: c_int, address: *const sockaddr, _address_len: socklen_t) -> Result<c_int> {
+    // XXX with UDP, should recieve messages only from that peer after this
+    // XXX Check address_len
+    if (*address).sa_family as i32 != AF_INET {
+        return Err(Error::new(EINVAL))
+    };
+    let address = &*(address as *const sockaddr_in);
+    let s_addr =address.sin_addr.s_addr;
+    let path = format!("{}.{}.{}.{}:{}", s_addr[0], s_addr[1], s_addr[2], s_addr[3], ntohs(address.sin_port));
+    let fd = syscall::dup(socket as usize, path.as_bytes())?;
+    let ret = syscall::dup2(fd, socket as usize, &vec![]);
+    let _ = syscall::close(fd);
+    ret?;
+    Ok(0)
+});
+
+libc_fn!(unsafe recv(socket: c_int, buffer: *mut c_void, length: size_t, flags: c_int) -> Result<ssize_t> {
+    // XXX flags
+    if flags != 0 {
+        Err(Error::new(EOPNOTSUPP))
+    } else {
+        let buf = slice::from_raw_parts_mut(buffer as *mut u8, length);
+        Ok(syscall::read(socket as usize, buf)? as ssize_t)
+    }
+});
+
+libc_fn!(unsafe send(socket: c_int, buffer: *const c_void, length: size_t, flags: c_int) -> Result<ssize_t> {
+    if flags != 0 {
+        Err(Error::new(EOPNOTSUPP))
+    } else {
+        let buf = slice::from_raw_parts(buffer as *const u8, length);
+        Ok(syscall::write(socket as usize, buf)? as ssize_t)
+    }
+});
+
+libc_fn!(htonl(hostlong: u32) -> [u8; 4] {
+    let mut netlong = [0; 4];
+    BigEndian::write_u32(&mut netlong, hostlong);
+    netlong
+});
+
+libc_fn!(htons(hostshort: u16) -> [u8; 2] {
+    let mut netshort = [0; 2];
+    BigEndian::write_u16(&mut netshort, hostshort);
+    netshort
+});
+
+libc_fn!(ntohl(netlong: [u8; 4]) -> u32 {
+    BigEndian::read_u32(&netlong)
+});
+
+libc_fn!(ntohs(netshort: [u8; 2]) -> u16 {
+    BigEndian::read_u16(&netshort)
+});

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -7,9 +7,9 @@ use collections::Vec;
 use byteorder::{BigEndian, ByteOrder};
 
 
-const AF_INET: c_int = 2;
-const SOCK_STREAM: c_int = 1;
-const SOCK_DGRAM: c_int = 2;
+pub const AF_INET: c_int = 2;
+pub const SOCK_STREAM: c_int = 1;
+pub const SOCK_DGRAM: c_int = 2;
 
 static mut NTOA_ADDR: Option<Vec<u8>> = None;
 

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -1,7 +1,8 @@
 use core::str::{self, FromStr};
+use core::mem;
 use ::types::{c_int, c_char, size_t, c_void, ssize_t, socklen_t, in_addr, sockaddr, sockaddr_in};
-use syscall::{self, O_RDWR, O_WRONLY};
-use syscall::error::{Error, EPROTOTYPE, EPROTONOSUPPORT, EAFNOSUPPORT, EINVAL, EOPNOTSUPP};
+use syscall::{self, O_RDWR};
+use syscall::error::{Error, EPROTOTYPE, EPROTONOSUPPORT, EAFNOSUPPORT, EINVAL, EOPNOTSUPP, ENOBUFS};
 use core::slice;
 use collections::Vec;
 use byteorder::{BigEndian, ByteOrder};
@@ -111,6 +112,40 @@ libc_fn!(unsafe sendto(socket: c_int, message: *const c_void, length: size_t, fl
         Ok(ret)
     } else {
         Err(Error::new(EOPNOTSUPP))
+    }
+});
+
+libc_fn!(unsafe getpeername(socket: c_int, address: *mut sockaddr, address_len: *mut socklen_t) -> Result<c_int> {
+    // XXX will need to be changed for other sockaddr types
+    if *address_len < mem::size_of::<sockaddr_in>() {
+        return Err(Error::new(ENOBUFS));
+    }
+    *address_len = mem::size_of::<sockaddr_in>();
+    let addr = &mut *(address as *mut sockaddr_in);
+    addr.sin_family = AF_INET as u16;
+
+    let mut path = [0; 4096];
+    syscall::fpath(socket as usize, &mut path)?;
+    let start;
+    let sep;
+    let end;
+    {
+        let mut iter = path.iter();
+        start = iter.position(|x| *x == b':').ok_or(Error::new(EINVAL))? + 1;
+        sep = start + iter.position(|x| *x == b':').ok_or(Error::new(EINVAL))?;
+        end = sep + 1 + iter.position(|x| *x == b'/').ok_or(Error::new(EINVAL))?;
+    }
+    path[sep] = b'\0';
+
+    if inet_aton(&path[start] as *const u8 as *const c_char, &mut addr.sin_addr) == 1 {
+        if let Ok(port) = u16::from_str(str::from_utf8_unchecked(&path[sep+1..end])) {
+            addr.sin_port = htons(port);
+            Ok(0)
+        } else {
+            Err(Error::new(EINVAL))
+        }
+    } else {
+        Err(Error::new(EINVAL)) // ?
     }
 });
 

--- a/newlib/libc/sys/redox/src/types.rs
+++ b/newlib/libc/sys/redox/src/types.rs
@@ -76,3 +76,12 @@ pub struct sockaddr_in {
     pub sin_addr: in_addr,
     __pad: [u8; 8]
 }
+
+#[repr(C)]
+pub struct hostent {
+    pub h_name: *const c_char,
+    pub h_aliases: *const *const c_char,
+    pub h_addrtype: c_int,
+    pub h_length: c_int,
+    pub h_addr_list: *const *const c_char
+}

--- a/newlib/libc/sys/redox/src/types.rs
+++ b/newlib/libc/sys/redox/src/types.rs
@@ -47,6 +47,7 @@ pub type wchar_t = i16;
 pub type off_t = usize;
 pub type mode_t = u16;
 pub type time_t = i64;
+pub type suseconds_t = c_long;
 pub type pid_t = c_int;
 pub type gid_t = usize;
 pub type uid_t = usize;
@@ -84,4 +85,21 @@ pub struct hostent {
     pub h_addrtype: c_int,
     pub h_length: c_int,
     pub h_addr_list: *const *const c_char
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct timeval {
+    pub tv_sec: time_t,
+    pub tv_usec: suseconds_t
+}
+
+pub type fd_mask = c_ulong;
+pub const FD_SETSIZE: usize = 64;
+pub const NFDBITS: usize = 8 * 8; // Bits in a fd_mask
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct fd_set {
+    pub fds_bits: [fd_mask; (FD_SETSIZE + NFDBITS - 1) / NFDBITS]
 }

--- a/newlib/libc/sys/redox/src/types.rs
+++ b/newlib/libc/sys/redox/src/types.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, dead_code)]
 
 // Copied from libc crate
 #[repr(u8)]
@@ -50,3 +50,29 @@ pub type time_t = i64;
 pub type pid_t = c_int;
 pub type gid_t = usize;
 pub type uid_t = usize;
+
+
+// Socket related types
+pub type in_addr_t = [u8; 4];
+pub type sa_family_t = u16;
+pub type socklen_t = size_t; 
+pub type in_port_t = [u8; 2];
+
+#[repr(C)]
+pub struct in_addr {
+    pub s_addr: in_addr_t
+}
+
+#[repr(C)]
+pub struct sockaddr {
+    pub sa_family: sa_family_t,
+    sa_data: [c_char; 14]
+}
+
+#[repr(C)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    __pad: [u8; 8]
+}

--- a/newlib/libc/sys/redox/src/unimpl.rs
+++ b/newlib/libc/sys/redox/src/unimpl.rs
@@ -105,7 +105,7 @@ libc_fn!(_isatty(file: c_int) -> c_int {
 libc_fn!(unsafe select(nfds: c_int, readfds: *mut fd_set, writefds: *mut fd_set, errorfds: *mut fd_set, _timeout: *mut timeval) -> Result<c_int> {
     use ::types::{FD_SETSIZE, NFDBITS};
     let mut ret = 0;
-    syscall::write(2, b"unimplemented: select()").unwrap();
+    syscall::write(2, b"unimplemented: select()\n").unwrap();
     if !readfds.is_null() {
         for i in 0..FD_SETSIZE {
              if ((*readfds).fds_bits[i/NFDBITS] & (1 << (i % NFDBITS))) != 0 {

--- a/newlib/libc/sys/redox/src/unimpl.rs
+++ b/newlib/libc/sys/redox/src/unimpl.rs
@@ -1,5 +1,5 @@
 use syscall;
-use ::types::{c_uint, c_int, c_char, gid_t, uid_t, c_void, c_long, mode_t};
+use ::types::{c_uint, c_int, c_char, gid_t, uid_t, c_void, c_long, mode_t, timeval, fd_set};
 use syscall::error::{Error, EACCES, EPERM, EINVAL};
 use core::ptr::null;
 
@@ -100,4 +100,28 @@ libc_fn!(unsafe vfork() -> c_int {
 
 libc_fn!(_isatty(file: c_int) -> c_int {
     (file == 0 || file == 1 || file == 2) as c_int
+});
+
+libc_fn!(unsafe select(nfds: c_int, readfds: *mut fd_set, writefds: *mut fd_set, errorfds: *mut fd_set, _timeout: *mut timeval) -> Result<c_int> {
+    use ::types::{FD_SETSIZE, NFDBITS};
+    let mut ret = 0;
+    syscall::write(2, b"unimplemented: select()").unwrap();
+    if !readfds.is_null() {
+        for i in 0..FD_SETSIZE {
+             if ((*readfds).fds_bits[i/NFDBITS] & (1 << (i % NFDBITS))) != 0 {
+                 ret += 1;
+             }
+        }
+    }
+    if !writefds.is_null() {
+        for i in 0..FD_SETSIZE {
+             if ((*writefds).fds_bits[i/NFDBITS] & (1 << (i % NFDBITS))) != 0 {
+                 ret += 1;
+             }
+        }
+    }
+    if !errorfds.is_null() {
+        (*errorfds).fds_bits = [0; (FD_SETSIZE + NFDBITS - 1) / NFDBITS];
+    }
+    Ok(ret)
 });

--- a/newlib/libc/sys/redox/sys/socket.h
+++ b/newlib/libc/sys/redox/sys/socket.h
@@ -1,0 +1,67 @@
+#ifndef _SYS_SOCKET_H
+#define _SYS_SOCKET_H
+#include <sys/types.h>
+#include <stdint.h>
+
+typedef size_t socklen_t;
+typedef uint16_t sa_family_t;
+typedef uint16_t in_port_t;
+typedef uint32_t in_addr_t;
+
+#define AF_UNSPEC 0
+#define AF_INET 2
+
+#define SOCK_STREAM 1
+#define SOCK_DGRAM 2
+
+#define	IPPROTO_IP 0
+#define	IPPROTO_ICMP 1
+#define	IPPROTO_TCP 6
+#define	IPPROTO_UDP 17
+
+#define SO_KEEPALIVE 0x0008
+
+#define SOL_SOCKET 0xffff
+
+struct sockaddr {
+    sa_family_t sa_family;
+    char sa_data[14];
+};
+
+struct in_addr {
+    in_addr_t s_addr;
+};
+
+struct sockaddr_in {
+    sa_family_t sin_family;
+    in_port_t sin_port;
+    struct in_addr sin_addr;
+    unsigned char __pad[8];
+};
+
+
+
+int connect(int socket, const struct sockaddr *address, socklen_t address_len);
+ssize_t recv(int socket, void *buffer, size_t length, int flags);
+ssize_t send(int socket, const void *buffer, size_t length, int flags);
+struct hostent *gethostbyname(const char *name);
+int socket(int domain, int type, int protocol);
+int bind(int socket, const struct sockaddr *address, socklen_t address_len);
+int setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len);
+int getsockname(int socket, struct sockaddr *restrict address, socklen_t *restrict address_len);
+int getpeername(int socket, struct sockaddr *restrict address, socklen_t *restrict address_len);
+int listen(int socket, int backlog);
+int accept(int socket, struct sockaddr *restrict address, socklen_t *restrict address_len);
+ssize_t recvfrom(int socket, void *restrict buffer, size_t length,
+                 int flags, struct sockaddr *restrict address,
+                 socklen_t *restrict address_len);
+ssize_t sendto(int socket, const void *message, size_t length,
+           int flags, const struct sockaddr *dest_addr,
+           socklen_t dest_len);
+uint32_t htonl(uint32_t hostlong);
+uint16_t htons(uint16_t hostshort);
+uint32_t ntohl(uint32_t netlong);
+uint16_t ntohs(uint16_t netshort);
+char *inet_ntoa(struct in_addr in);
+int inet_aton(const char *cp, struct in_addr *inp);
+#endif

--- a/newlib/libc/sys/redox/sys/socket.h
+++ b/newlib/libc/sys/redox/sys/socket.h
@@ -24,7 +24,6 @@ struct sockaddr {
 int connect(int socket, const struct sockaddr *address, socklen_t address_len);
 ssize_t recv(int socket, void *buffer, size_t length, int flags);
 ssize_t send(int socket, const void *buffer, size_t length, int flags);
-struct hostent *gethostbyname(const char *name);
 int socket(int domain, int type, int protocol);
 int bind(int socket, const struct sockaddr *address, socklen_t address_len);
 int setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len);

--- a/newlib/libc/sys/redox/sys/socket.h
+++ b/newlib/libc/sys/redox/sys/socket.h
@@ -3,43 +3,23 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-typedef size_t socklen_t;
-typedef uint16_t sa_family_t;
-typedef uint16_t in_port_t;
-typedef uint32_t in_addr_t;
-
 #define AF_UNSPEC 0
 #define AF_INET 2
 
 #define SOCK_STREAM 1
 #define SOCK_DGRAM 2
 
-#define	IPPROTO_IP 0
-#define	IPPROTO_ICMP 1
-#define	IPPROTO_TCP 6
-#define	IPPROTO_UDP 17
-
 #define SO_KEEPALIVE 0x0008
 
 #define SOL_SOCKET 0xffff
+
+typedef size_t socklen_t;
+typedef uint16_t sa_family_t;
 
 struct sockaddr {
     sa_family_t sa_family;
     char sa_data[14];
 };
-
-struct in_addr {
-    in_addr_t s_addr;
-};
-
-struct sockaddr_in {
-    sa_family_t sin_family;
-    in_port_t sin_port;
-    struct in_addr sin_addr;
-    unsigned char __pad[8];
-};
-
-
 
 int connect(int socket, const struct sockaddr *address, socklen_t address_len);
 ssize_t recv(int socket, void *buffer, size_t length, int flags);
@@ -58,10 +38,4 @@ ssize_t recvfrom(int socket, void *restrict buffer, size_t length,
 ssize_t sendto(int socket, const void *message, size_t length,
            int flags, const struct sockaddr *dest_addr,
            socklen_t dest_len);
-uint32_t htonl(uint32_t hostlong);
-uint16_t htons(uint16_t hostshort);
-uint32_t ntohl(uint32_t netlong);
-uint16_t ntohs(uint16_t netshort);
-char *inet_ntoa(struct in_addr in);
-int inet_aton(const char *cp, struct in_addr *inp);
 #endif


### PR DESCRIPTION
https://github.com/redox-os/newlib/pull/1 can be closed now. This shouldn't be merged yet, but I thought I might as well create a PR to keep track of it.

This test program works; but some fairly important things, like hostname lookup, are still needed:

```c
#include <sys/socket.h>
#include <stdio.h>
#include <unistd.h>
#include <string.h>
#include <netinet/in.h>
#include <arpa/inet.h>

int main() {
    int fd = socket(AF_INET, SOCK_STREAM, 0);

    struct sockaddr_in addr;
    addr.sin_family = AF_INET;
    addr.sin_port = htons(80);
    inet_aton("172.217.4.142", &addr.sin_addr);

    connect(fd, (struct sockaddr*)&addr, sizeof(addr));
    char *req = "GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n";
    send(fd, req, strlen(req), 0);

    char c;
    while (recv(fd, &c, 1, 0) == 1)
        putchar(c);
    putchar('\n');

    close(fd);
}
```