### PR TITLE
Use libc crate again

### DIFF
--- a/newlib/libc/sys/redox/Cargo.toml
+++ b/newlib/libc/sys/redox/Cargo.toml
@@ -12,3 +12,4 @@ lto = true
 [dependencies]
 redox_syscall = "0.1"
 byteorder = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false }

--- a/newlib/libc/sys/redox/src/file.rs
+++ b/newlib/libc/sys/redox/src/file.rs
@@ -1,6 +1,6 @@
 use syscall::{self, O_CLOEXEC, O_STAT, O_CREAT, O_EXCL, O_DIRECTORY, O_WRONLY};
 use core::slice;
-use ::types::{c_int, c_char, off_t, mode_t, c_void};
+use libc::{c_int, c_char, off_t, mode_t, c_void};
 
 pub const PATH_MAX: usize = 4096;
 

--- a/newlib/libc/sys/redox/src/hostname.rs
+++ b/newlib/libc/sys/redox/src/hostname.rs
@@ -5,7 +5,8 @@ use collections::string::ToString;
 use collections::{Vec, String};
 use ::dns::{Dns, DnsQuery};
 use syscall::{self, Result, EINVAL, Error};
-use ::types::{in_addr, hostent, c_char};
+use libc::c_char;
+use ::types::{in_addr, hostent};
 
 static mut HOST_ENTRY: hostent = hostent { h_name: null(), h_aliases: null(), h_addrtype: 0, h_length: 0, h_addr_list: null() };
 static mut HOST_NAME: Option<Vec<u8>> = None;

--- a/newlib/libc/sys/redox/src/lib.rs
+++ b/newlib/libc/sys/redox/src/lib.rs
@@ -7,10 +7,11 @@ extern crate collections;
 extern crate compiler_builtins;
 extern crate byteorder;
 extern crate alloc;
+extern crate libc;
 
 use core::{ptr, mem, intrinsics, slice};
 use collections::Vec;
-use ::types::{c_int, c_void, c_char, size_t};
+use libc::{c_int, c_void, c_char, size_t};
 
 #[macro_use]
 mod macros;

--- a/newlib/libc/sys/redox/src/mallocnull.rs
+++ b/newlib/libc/sys/redox/src/mallocnull.rs
@@ -1,5 +1,5 @@
 use core::mem;
-use ::types::{c_void, size_t};
+use libc::{c_void, size_t};
 
 /// Malloc memory if pointer is null, and free on drop
 pub struct MallocNull<T> {

--- a/newlib/libc/sys/redox/src/process.rs
+++ b/newlib/libc/sys/redox/src/process.rs
@@ -1,4 +1,5 @@
-use ::types::{c_char, c_int, c_void, size_t, pid_t, gid_t, uid_t, ptrdiff_t};
+use libc::{c_char, c_int, c_void, size_t, gid_t, uid_t, ptrdiff_t};
+use ::types::pid_t;
 use core::slice;
 use core::ptr::null;
 use collections::Vec;

--- a/newlib/libc/sys/redox/src/redox.rs
+++ b/newlib/libc/sys/redox/src/redox.rs
@@ -1,5 +1,5 @@
 use syscall;
-use ::types::{c_int, c_char, c_void, size_t};
+use libc::{c_int, c_char, c_void, size_t};
 use core::slice;
 
 libc_fn!(unsafe redox_fevent(file: c_int, flags: c_int) -> Result<c_int> {

--- a/newlib/libc/sys/redox/src/socket.rs
+++ b/newlib/libc/sys/redox/src/socket.rs
@@ -1,6 +1,7 @@
 use core::str::{self, FromStr};
 use core::mem;
-use ::types::{c_int, c_char, size_t, c_void, ssize_t, socklen_t, in_addr, sockaddr, sockaddr_in};
+use libc::{c_int, c_char, size_t, c_void, ssize_t};
+use ::types::{socklen_t, in_addr, sockaddr, sockaddr_in};
 use syscall::{self, O_RDWR};
 use syscall::error::{Error, EPROTOTYPE, EPROTONOSUPPORT, EAFNOSUPPORT, EINVAL, EOPNOTSUPP, ENOBUFS};
 use core::slice;

--- a/newlib/libc/sys/redox/src/time.rs
+++ b/newlib/libc/sys/redox/src/time.rs
@@ -1,7 +1,7 @@
 use syscall;
 use syscall::data::TimeSpec;
 use syscall::error::{Error, EFAULT};
-use ::types::{c_int, c_void, time_t, c_long};
+use libc::{c_int, c_void, time_t, c_long};
 
 pub struct TimeVal {
     pub tv_sec: time_t,

--- a/newlib/libc/sys/redox/src/types.rs
+++ b/newlib/libc/sys/redox/src/types.rs
@@ -1,62 +1,16 @@
 #![allow(non_camel_case_types, dead_code)]
 
-// Copied from libc crate
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
+use libc;
 
-pub type int8_t = i8;
-pub type int16_t = i16;
-pub type int32_t = i32;
-pub type int64_t = i64;
-pub type uint8_t = u8;
-pub type uint16_t = u16;
-pub type uint32_t = u32;
-pub type uint64_t = u64;
+pub type pid_t = libc::c_int;
 
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-pub type c_float = f32;
-pub type c_double = f64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type intmax_t = i64;
-pub type uintmax_t = u64;
-
-pub type size_t = usize;
-pub type ptrdiff_t = isize;
-pub type intptr_t = isize;
-pub type uintptr_t = usize;
-pub type ssize_t = isize;
-
-pub type c_char = i8;
-pub type c_long = i64;
-pub type c_ulong = u64;
-
-pub type wchar_t = i16;
-
-pub type off_t = usize;
-pub type mode_t = u16;
 pub type time_t = i64;
-pub type suseconds_t = c_long;
-pub type pid_t = c_int;
-pub type gid_t = usize;
-pub type uid_t = usize;
-
+pub type suseconds_t = libc::c_long;
 
 // Socket related types
 pub type in_addr_t = [u8; 4];
 pub type sa_family_t = u16;
-pub type socklen_t = size_t; 
+pub type socklen_t = libc::size_t;
 pub type in_port_t = [u8; 2];
 
 #[repr(C)]
@@ -67,7 +21,7 @@ pub struct in_addr {
 #[repr(C)]
 pub struct sockaddr {
     pub sa_family: sa_family_t,
-    sa_data: [c_char; 14]
+    sa_data: [libc::c_char; 14]
 }
 
 #[repr(C)]
@@ -80,11 +34,11 @@ pub struct sockaddr_in {
 
 #[repr(C)]
 pub struct hostent {
-    pub h_name: *const c_char,
-    pub h_aliases: *const *const c_char,
-    pub h_addrtype: c_int,
-    pub h_length: c_int,
-    pub h_addr_list: *const *const c_char
+    pub h_name: *const libc::c_char,
+    pub h_aliases: *const *const libc::c_char,
+    pub h_addrtype: libc::c_int,
+    pub h_length: libc::c_int,
+    pub h_addr_list: *const *const libc::c_char
 }
 
 #[repr(C)]
@@ -94,7 +48,7 @@ pub struct timeval {
     pub tv_usec: suseconds_t
 }
 
-pub type fd_mask = c_ulong;
+pub type fd_mask = libc::c_ulong;
 pub const FD_SETSIZE: usize = 64;
 pub const NFDBITS: usize = 8 * 8; // Bits in a fd_mask
 

--- a/newlib/libc/sys/redox/src/unimpl.rs
+++ b/newlib/libc/sys/redox/src/unimpl.rs
@@ -1,5 +1,6 @@
 use syscall;
-use ::types::{c_uint, c_int, c_char, gid_t, uid_t, c_void, c_long, mode_t, timeval, fd_set};
+use libc::{c_uint, c_int, c_char, gid_t, uid_t, c_void, c_long, mode_t};
+use ::types::{timeval, fd_set};
 use syscall::error::{Error, EACCES, EPERM, EINVAL};
 use core::ptr::null;
 


### PR DESCRIPTION
It seems libc can be used without std, by disabling that default
feature.