### PR TITLE
Call cargo update

### DIFF
--- a/newlib/libc/sys/redox/Makefile.am
+++ b/newlib/libc/sys/redox/Makefile.am
@@ -27,6 +27,7 @@ rust_sources = \
     src/dns/query.rs
 
 $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Xargo.toml Cargo.toml $(rust_sources)
+	cd $(srcdir); cargo update
 	cd $(srcdir); CC=x86_64-elf-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
 
 lib.a: $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a

--- a/newlib/libc/sys/redox/Makefile.in
+++ b/newlib/libc/sys/redox/Makefile.in
@@ -460,6 +460,7 @@ uninstall-am:
 
 
 $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Xargo.toml Cargo.toml $(rust_sources)
+	cd $(srcdir); cargo update
 	cd $(srcdir); CC=x86_64-elf-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
 
 lib.a: $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a


### PR DESCRIPTION
This hopefully will fix the latest Jenkins build error, and similar ones in the future.