### PR TITLE
Use compiler_builtins from rust source tree

### DIFF
--- a/newlib/libc/sys/redox/Cargo.toml
+++ b/newlib/libc/sys/redox/Cargo.toml
@@ -13,6 +13,3 @@ lto = true
 byteorder = { version = "1", default-features = false }
 libc = { git = "https://github.com/rust-lang/libc", default-features = false }
 redox_syscall = "0.1"
-
-[dependencies.compiler_builtins]
-git = "https://github.com/rust-lang-nursery/compiler-builtins"

--- a/newlib/libc/sys/redox/Xargo.toml
+++ b/newlib/libc/sys/redox/Xargo.toml
@@ -1,3 +1,6 @@
 [dependencies.alloc]
 
 [dependencies.alloc_system]
+
+[dependencies.compiler_builtins]
+stage = 1


### PR DESCRIPTION
I don't think this is likely to be an issue, but it is probably best to match the version there. So I thought I might as well submit a PR since I figured out why this wasn't working.