### PR TITLE
Add termios functions

### DIFF
--- a/newlib/libc/sys/redox/Cargo.toml
+++ b/newlib/libc/sys/redox/Cargo.toml
@@ -13,3 +13,4 @@ lto = true
 byteorder = { version = "1", default-features = false }
 libc = { git = "https://github.com/rust-lang/libc", default-features = false }
 redox_syscall = "0.1"
+redox_termios = "0.1"

--- a/newlib/libc/sys/redox/include/termios.h
+++ b/newlib/libc/sys/redox/include/termios.h
@@ -1,0 +1,152 @@
+/*
+ * termios.h
+ *
+ * Contains the definitions used by the terminal I/O interfaces.
+ */
+
+#ifndef _TERMIOS_H
+#define _TERMIOS_H
+
+#include <sys/types.h>
+
+typedef unsigned char  cc_t;
+typedef unsigned int   speed_t;
+typedef unsigned int   tcflag_t;
+
+#define VEOF       0
+#define VEOL       1
+#define VEOL2      2
+#define VERASE     3
+#define VWERASE    4
+#define VKILL      5
+#define VREPRINT   6
+#define VSWTC      7
+#define VINTR      8
+#define VQUIT      9
+#define VSUSP     10
+#define VSTART    12
+#define VSTOP     13
+#define VLNEXT    14
+#define VDISCARD  15
+#define VMIN      16
+#define VTIME     17
+
+// flags for input modes
+#define IGNBRK 000001
+#define BRKINT 000002
+#define IGNPAR 000004
+#define PARMRK 000010
+#define INPCK  000020
+#define ISTRIP 000040
+#define INLCR  000100
+#define IGNCR  000200
+#define ICRNL  000400
+#define IXON   001000
+#define IXOFF  002000
+
+// flags for output modes
+#define OPOST  000001
+#define ONLCR  000002
+#define OLCUC  000004
+#define OCRNL  000010
+#define ONOCR  000020
+#define ONLRET 000040
+#define OFILL  0000100
+#define OFDEL  0000200
+
+// baud rates
+#define B0       000000
+#define B50      000001
+#define B75      000002
+#define B110     000003
+#define B134     000004
+#define B150     000005
+#define B200     000006
+#define B300     000007
+#define B600     000010
+#define B1200    000011
+#define B1800    000012
+#define B2400    000013
+#define B4800    000014
+#define B9600    000015
+#define B19200   000016
+#define B38400   000017
+#define B57600   000020
+#define B115200  000021
+#define B230400  000022
+#define B460800  000023
+#define B500000  000024
+#define B576000  000025
+#define B921600  000026
+#define B1000000 000027
+#define B1152000 000030
+#define B1500000 000031
+#define B2000000 000032
+#define B2500000 000033
+#define B3000000 000034
+#define B3500000 000035
+#define B4000000 000036
+
+// control modes
+#define CSIZE   0001400
+#define   CS5   0000000
+#define   CS6   0000400
+#define   CS7   0001000
+#define   CS8   0001400
+#define CSTOPB  0002000
+#define CREAD   0004000
+#define PARENB  0010000
+#define PARODD  0020000
+#define HUPCL   0040000
+#define CLOCAL  0100000
+
+// local modes
+#define ISIG    0x00000080
+#define ICANON  0x00000100
+#define ECHO    0x00000008
+#define ECHOE   0x00000002
+#define ECHOK   0x00000004
+#define ECHONL  0x00000010
+#define NOFLSH  0x80000000
+#define TOSTOP  0x00400000
+#define IEXTEN  0x00000400
+
+// tcsetattr() args
+#define TCSANOW   0x0001
+#define TCSADRAIN 0x0002
+#define TCSAFLUSH 0x0004
+
+// tcflush() args
+#define TCIFLUSH  0x0001
+#define TCIOFLUSH 0x0003
+#define TCOFLUSH  0x0002
+
+// tcflow() args
+#define TCIOFF    0x0001
+#define TCION     0x0002
+#define TCOOFF    0x0004
+#define TCOON     0x0008
+
+#define NCCS 32
+
+struct termios {
+	tcflag_t c_iflag;
+	tcflag_t c_oflag;
+	tcflag_t c_cflag;
+	tcflag_t c_lflag;
+	cc_t     c_cc[NCCS];
+};
+
+speed_t cfgetispeed(const struct termios *);
+speed_t cfgetospeed(const struct termios *);
+int     cfsetispeed(struct termios *, speed_t);
+int     cfsetospeed(struct termios *, speed_t);
+int     tcdrain(int);
+int     tcflow(int, int);
+int     tcflush(int, int);
+int     tcgetattr(int, struct termios *);
+pid_t   tcgetsid(int);
+int     tcsendbreak(int, int);
+int     tcsetattr(int, int, struct termios *);
+
+#endif

--- a/newlib/libc/sys/redox/src/lib.rs
+++ b/newlib/libc/sys/redox/src/lib.rs
@@ -19,6 +19,7 @@ extern crate byteorder;
 extern crate compiler_builtins;
 extern crate libc;
 extern crate syscall;
+extern crate redox_termios;
 
 use alloc::Vec;
 use core::{ptr, mem, intrinsics, slice};
@@ -39,6 +40,7 @@ pub mod user;
 pub mod redox;
 pub mod socket;
 pub mod hostname;
+pub mod termios;
 
 pub use mallocnull::MallocNull;
 pub use rawfile::RawFile;

--- a/newlib/libc/sys/redox/src/termios.rs
+++ b/newlib/libc/sys/redox/src/termios.rs
@@ -1,0 +1,93 @@
+#![allow(non_camel_case_types)]
+
+use libc::{self, c_int};
+use redox_termios::{tcflag_t, Termios};
+use syscall::{self, EINVAL, Error};
+use ::types::pid_t;
+
+type speed_t = libc::c_uint;
+
+// tcsetattr args
+pub const TCSANOW:   tcflag_t = 0x1;
+pub const TCSADRAIN: tcflag_t = 0x2;
+pub const TCSAFLUSH: tcflag_t = 0x4;
+
+// tcflush args
+pub const TCIFLUSH:  tcflag_t = 0x1;
+pub const TCIOFLUSH: tcflag_t = 0x3;
+pub const TCOFLUSH:  tcflag_t = 0x2;
+
+// tcflow args
+pub const TCIOFF: tcflag_t = 0x1;
+pub const TCION:  tcflag_t = 0x2;
+pub const TCOOFF: tcflag_t = 0x4;
+pub const TCOON:  tcflag_t = 0x8;
+
+libc_fn!(unsafe tcgetattr(fd: c_int, tio: *mut Termios) -> Result<c_int> {
+    let fd = syscall::dup(fd as usize, b"termios")?;
+    let res = syscall::read(fd, &mut *tio);
+    let _ = syscall::close(fd);
+
+    if res? == (&*tio).len() {
+        Ok(0)
+    } else {
+        Err(Error::new(EINVAL))
+    }
+});
+
+libc_fn!(unsafe tcsetattr(fd: c_int, _arg: c_int, tio: *mut Termios) -> Result<c_int> {
+    let fd = syscall::dup(fd as usize, b"termios")?;
+    let res = syscall::write(fd, &*tio);
+    let _ = syscall::close(fd);
+
+    if res? == (&*tio).len() {
+        Ok(0)
+    } else {
+        Err(Error::new(EINVAL))
+    }
+});
+
+libc_fn!(cfgetispeed(_tio: *mut Termios) -> speed_t {
+    // TODO
+    0 as speed_t
+});
+
+libc_fn!(cfgetospeed(_tio: *mut Termios) -> speed_t {
+    // TODO
+    0 as speed_t
+});
+
+libc_fn!(cfsetispeed(_tio: *mut Termios, _speed: speed_t) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});
+
+libc_fn!(cfsetospeed(_tio: *mut Termios, _speed: speed_t) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});
+
+libc_fn!(tcdrain(_i: c_int) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});
+
+libc_fn!(tcflow(_fd: c_int, _arg: c_int) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});
+
+libc_fn!(tcflush(_fd: c_int, _arg: c_int) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});
+
+libc_fn!(unsafe tcgetsid(_fd: c_int) -> pid_t {
+    // TODO
+    ::process::_getpid()
+});
+
+libc_fn!(tcsendbreak(_fd: c_int, _arg: c_int) -> Result<c_int> {
+    // TODO
+    Ok(0)
+});

--- a/newlib/libc/sys/redox/src/unimpl.rs
+++ b/newlib/libc/sys/redox/src/unimpl.rs
@@ -62,6 +62,18 @@ libc_fn!(_isatty(file: c_int) -> c_int {
     (file == 0 || file == 1 || file == 2) as c_int
 });
 
+libc_fn!(ttyname(fd: c_int) -> Result<*const c_char> {
+    UNIMPL!(ttyname, EINVAL)
+});
+
+libc_fn!(fpathconf(fildes: c_int, name: c_int) -> Result<c_long> {
+    UNIMPL!(fpathconf, EINVAL)
+});
+
+libc_fn!(getlogin() -> Result<*const c_char> {
+    UNIMPL!(getlogin, EINVAL)
+});
+
 libc_fn!(unsafe select(nfds: c_int, readfds: *mut fd_set, writefds: *mut fd_set, errorfds: *mut fd_set, _timeout: *mut timeval) -> Result<c_int> {
     use ::types::{FD_SETSIZE, NFDBITS};
     let mut ret = 0;

--- a/newlib/libc/sys/redox/sys/unistd.h
+++ b/newlib/libc/sys/redox/sys/unistd.h
@@ -13,6 +13,12 @@ extern "C" {
 #include <sys/_types.h>
 #include <stddef.h>
 
+#define _POSIX_VERSION      200112L
+#define _POSIX2_VERSION     200112L
+#define _POSIX2_C_VERSION   199209L
+#define _XOPEN_VERSION      500
+#define _XOPEN_XCU_VERSION  -1
+
 extern char **environ;
 
 void	_EXFUN(_exit, (int __status ) _ATTRIBUTE ((__noreturn__)));


### PR DESCRIPTION
This pull request adds `termios.h` and the required functions according to the POSIX specification. Most functions are stubs for now, but the most important ones (
 `tcgetattr` and `tcsetattr`) are implemented, mostly copied from [ticki/termion](https://github.com/ticki/termion/blob/master/src/sys/redox/attr.rs).

Additionally this pull requests adds some other stubs and defines which are required to compile libncurses and libreadline.