### PR TITLE
Use panic=abort

### DIFF
--- a/newlib/libc/sys/redox/Cargo.toml
+++ b/newlib/libc/sys/redox/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [profile.release]
 lto = true
+panic = "abort"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }


### PR DESCRIPTION
Required now that unwinding panics are the default on Redox.