### PR TITLE
Use -unknown- rather than -elf- in redox Makefiles

### DIFF
--- a/newlib/libc/sys/redox/Makefile.am
+++ b/newlib/libc/sys/redox/Makefile.am
@@ -31,7 +31,7 @@ rust_sources = \
 
 $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Xargo.toml Cargo.toml $(rust_sources)
 	cd $(srcdir); cargo update
-	cd $(srcdir); CC=x86_64-elf-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
+	cd $(srcdir); CC=x86_64-unknown-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
 
 lib.a: $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a
 	cp $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a lib.a

--- a/newlib/libc/sys/redox/Makefile.in
+++ b/newlib/libc/sys/redox/Makefile.in
@@ -465,7 +465,7 @@ uninstall-am:
 
 $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a: Xargo.toml Cargo.toml $(rust_sources)
 	cd $(srcdir); cargo update
-	cd $(srcdir); CC=x86_64-elf-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
+	cd $(srcdir); CC=x86_64-unknown-redox-gcc CFLAGS="$(CFLAGS) -I $(srcdir)/../../include" xargo build --target x86_64-unknown-redox --release
 
 lib.a: $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a
 	cp $(srcdir)/target/x86_64-unknown-redox/release/libnewlib_redox.a lib.a


### PR DESCRIPTION
Brings newlib inline with what is present in redox-os/libc.

Similar to https://github.com/redox-os/libc/pull/37.