### PR TITLE
 Fix the handling of NULL status in wait/waitpid

### DIFF
--- a/newlib/libc/sys/redox/src/process.rs
+++ b/newlib/libc/sys/redox/src/process.rs
@@ -190,7 +190,9 @@ libc_fn!(unsafe setuid(uid: uid_t) -> Result<c_int> {
 libc_fn!(unsafe _wait(status: *mut c_int) -> Result<c_int> {
     let mut buf = 0;
     let res = syscall::waitpid(0, &mut buf, 0)?;
-    *status = buf as c_int;
+    if !status.is_null() {
+        *status = buf as c_int;
+    }
     Ok(res as c_int)
 });
 
@@ -202,6 +204,8 @@ libc_fn!(unsafe waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> Resul
         pid as usize
     };
     let res = syscall::waitpid(pid as usize, &mut buf, options as usize)?;
-    *status = buf as c_int;
+    if !status.is_null() {
+        *status = buf as c_int;
+    }
     Ok(res as c_int)
 });


### PR DESCRIPTION
This fixes a crash in OpenTTD. The game uses this function with a NULL argument [here](https://github.com/OpenTTD/OpenTTD/blob/228f8fba55f55b4233ff635223ceb89f720638a5/src/music/extmidi.cpp#L100).

Relibc doesn't have this bug, this is handled properly there.